### PR TITLE
feat: add partial update category and tests, and requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+asgiref==3.8.1
+Django==5.1.6
+djangorestframework==3.15.2
+iniconfig==2.0.0
+packaging==24.2
+pluggy==1.5.0
+pytest==8.3.4
+pytest-django==4.10.0
+sqlparse==0.5.3

--- a/src/django_project/category_app/repository.py
+++ b/src/django_project/category_app/repository.py
@@ -30,7 +30,7 @@ class DjangoORMCategoryRepository(CategoryRepository):
             return Category(
                 id=category.id,
                 name=category.name,
-                description=category.description,
+                description=category.description,  # type: ignore
                 is_active=category.is_active,
             )
         except self.category_model.DoesNotExist:
@@ -53,7 +53,7 @@ class DjangoORMCategoryRepository(CategoryRepository):
             Category(
                 id=category.id,
                 name=category.name,
-                description=category.description,
+                description=category.description,  # type: ignore
                 is_active=category.is_active,
             )
             for category in self.category_model.objects.all()

--- a/src/django_project/category_app/serializers.py
+++ b/src/django_project/category_app/serializers.py
@@ -1,5 +1,3 @@
-from email.policy import default
-
 from rest_framework import serializers
 
 

--- a/src/django_project/category_app/tests/test_views.py
+++ b/src/django_project/category_app/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
 )
@@ -100,8 +101,8 @@ class TestListAPI:
         }
 
         response = APIClient().get(url)
-        assert response.status_code, 200
-        assert response.data, expected_data
+        assert response.status_code, 200  # type: ignore
+        assert response.data, expected_data  # type: ignore
 
 
 @pytest.mark.django_db
@@ -123,7 +124,7 @@ class TestRetrieveAPI:
         url = "/api/categories/123456789/"
         response = APIClient().get(url)
 
-        assert response.status_code, HTTP_400_BAD_REQUEST
+        assert response.status_code, HTTP_400_BAD_REQUEST  # type: ignore
 
     def test_return_category_when_exists(
         self,
@@ -154,8 +155,8 @@ class TestRetrieveAPI:
         }
 
         response = APIClient().get(url)
-        assert response.status_code, HTTP_200_OK
-        assert response.data, expected_data
+        assert response.status_code, HTTP_200_OK  # type: ignore
+        assert response.data, expected_data  # type: ignore
 
     def test_return_404_when_category_not_exists(self):
         """
@@ -170,7 +171,7 @@ class TestRetrieveAPI:
         url = f"/api/categories/{uuid.uuid4()}/"
 
         response = APIClient().get(url)
-        assert response.status_code, HTTP_404_NOT_FOUND
+        assert response.status_code, HTTP_404_NOT_FOUND  # type: ignore
 
 
 @pytest.mark.django_db
@@ -199,7 +200,7 @@ class TestCreateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_400_BAD_REQUEST
+        assert response.status_code, HTTP_400_BAD_REQUEST  # type: ignore
 
     def test_when_data_is_valid_return_201(
         self,
@@ -224,8 +225,8 @@ class TestCreateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_201_CREATED
-        created_category_id = uuid.UUID(response.data["id"])
+        assert response.status_code, HTTP_201_CREATED  # type: ignore
+        created_category_id = uuid.UUID(response.data["id"])  # type: ignore
         assert category_repository.get_by_id(
             category_id=created_category_id
         ) == Category(
@@ -270,8 +271,8 @@ class TestUpdateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_400_BAD_REQUEST
-        assert response.data == {
+        assert response.status_code, HTTP_400_BAD_REQUEST  # type: ignore
+        assert response.data == {  # type: ignore
             "id": ["Must be a valid UUID."],
             "name": ["This field may not be blank."],
             "is_active": ["This field is required."],
@@ -303,12 +304,12 @@ class TestUpdateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
 
         updated_category = category_repository.get_by_id(category_movie.id)
-        assert updated_category.name == "Movies 2"
-        assert updated_category.description == "Movies category updated"
-        assert updated_category.is_active is True
+        assert updated_category.name == "Movies 2"  # type: ignore
+        assert updated_category.description == "Movies category updated"  # type: ignore
+        assert updated_category.is_active is True  # type: ignore
 
     def test_when_category_not_exists_return_404(self):
         """
@@ -331,7 +332,7 @@ class TestUpdateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_404_NOT_FOUND
+        assert response.status_code, HTTP_404_NOT_FOUND  # type: ignore
 
 
 @pytest.mark.django_db
@@ -353,8 +354,8 @@ class TestDeleteAPI:
         url = "/api/categories/1234567890/"
         response = APIClient().delete(url)
 
-        assert response.status_code, HTTP_400_BAD_REQUEST
-        assert response.data == {"id": ["Must be a valid UUID."]}
+        assert response.status_code, HTTP_400_BAD_REQUEST  # type: ignore
+        assert response.data == {"id": ["Must be a valid UUID."]}  # type: ignore
 
     def test_when_category_not_exists_return_404(self):
         """
@@ -369,7 +370,7 @@ class TestDeleteAPI:
         url = f"/api/categories/{uuid.uuid4()}/"
         response = APIClient().delete(url)
 
-        assert response.status_code, HTTP_404_NOT_FOUND
+        assert response.status_code, HTTP_404_NOT_FOUND  # type: ignore
 
     def test_when_category_exists_return_204(
         self,
@@ -389,7 +390,7 @@ class TestDeleteAPI:
         url = f"/api/categories/{category_movie.id}/"
         response = APIClient().delete(url)
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
         assert category_repository.get_by_id(category_movie.id) is None
 
 
@@ -409,7 +410,7 @@ class TestPartialUpdateAPI:
         The expected result is a 400 status code.
         """
 
-        url = f"/api/categories/1234567890/"
+        url = "/api/categories/1234567890/"
         response = APIClient().patch(
             path=url,
             data={
@@ -419,7 +420,7 @@ class TestPartialUpdateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_400_BAD_REQUEST
+        assert response.status_code, HTTP_400_BAD_REQUEST  # type: ignore
 
     def test_when_category_not_exists_return_404(self):
         """
@@ -442,7 +443,7 @@ class TestPartialUpdateAPI:
             format="json",
         )
 
-        assert response.status_code, HTTP_404_NOT_FOUND
+        assert response.status_code, HTTP_404_NOT_FOUND  # type: ignore
 
     def test_when_category_exists_update_only_name_and_return_204(
         self,
@@ -466,12 +467,12 @@ class TestPartialUpdateAPI:
             },
         )
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
 
         partial_updated_category = category_repository.get_by_id(category_movie.id)
-        assert partial_updated_category.name == "Movies 2"
-        assert partial_updated_category.description == category_movie.description
-        assert partial_updated_category.is_active == category_movie.is_active
+        assert partial_updated_category.name == "Movies 2"  # type: ignore
+        assert partial_updated_category.description == category_movie.description  # type: ignore
+        assert partial_updated_category.is_active == category_movie.is_active  # type: ignore
 
     def test_when_category_exists_update_only_description_and_return_204(
         self,
@@ -495,12 +496,12 @@ class TestPartialUpdateAPI:
             },
         )
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
 
         partial_updated_category = category_repository.get_by_id(category_movie.id)
-        assert partial_updated_category.name == category_movie.name
-        assert partial_updated_category.description == "Movies category updated"
-        assert partial_updated_category.is_active == category_movie.is_active
+        assert partial_updated_category.name == category_movie.name  # type: ignore
+        assert partial_updated_category.description == "Movies category updated"  # type: ignore
+        assert partial_updated_category.is_active == category_movie.is_active  # type: ignore
 
     def test_when_category_exists_update_only_is_active_and_return_204(
         self,
@@ -524,12 +525,12 @@ class TestPartialUpdateAPI:
             },
         )
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
 
         partial_updated_category = category_repository.get_by_id(category_movie.id)
-        assert partial_updated_category.name == category_movie.name
-        assert partial_updated_category.description == category_movie.description
-        assert partial_updated_category.is_active == False
+        assert partial_updated_category.name == category_movie.name  # type: ignore
+        assert partial_updated_category.description == category_movie.description  # type: ignore
+        assert partial_updated_category.is_active is False  # type: ignore
 
     def test_when_category_exists_update_all_fields_and_return_204(
         self,
@@ -555,9 +556,9 @@ class TestPartialUpdateAPI:
             },
         )
 
-        assert response.status_code, HTTP_204_NO_CONTENT
+        assert response.status_code, HTTP_204_NO_CONTENT  # type: ignore
 
         partial_updated_category = category_repository.get_by_id(category_movie.id)
-        assert partial_updated_category.name == "Movies 2"
-        assert partial_updated_category.description == "Movies category updated"
-        assert partial_updated_category.is_active == False
+        assert partial_updated_category.name == "Movies 2"  # type: ignore
+        assert partial_updated_category.description == "Movies category updated"  # type: ignore
+        assert partial_updated_category.is_active is False  # type: ignore

--- a/src/django_project/category_app/tests/test_views.py
+++ b/src/django_project/category_app/tests/test_views.py
@@ -391,3 +391,173 @@ class TestDeleteAPI:
 
         assert response.status_code, HTTP_204_NO_CONTENT
         assert category_repository.get_by_id(category_movie.id) is None
+
+
+@pytest.mark.django_db
+class TestPartialUpdateAPI:
+    """
+    Test the Partial Update API.
+    """
+
+    def test_when_payload_is_invalid_return_400(self):
+        """
+        Test that the API returns 400 when the given payload is invalid.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given payload is invalid,
+        it should return a 400 error.
+
+        The expected result is a 400 status code.
+        """
+
+        url = f"/api/categories/1234567890/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "name": "",
+                "description": "Movies category",
+            },
+            format="json",
+        )
+
+        assert response.status_code, HTTP_400_BAD_REQUEST
+
+    def test_when_category_not_exists_return_404(self):
+        """
+        Test that the API returns 404 when the given ID does not exist.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given ID does not exist,
+        it should return a 404 error.
+
+        The expected result is a 404 status code.
+        """
+
+        url = f"/api/categories/{uuid.uuid4()}/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "name": "Movies 2",
+                "description": "Movies category updated",
+                "is_active": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code, HTTP_404_NOT_FOUND
+
+    def test_when_category_exists_update_only_name_and_return_204(
+        self,
+        category_movie: Category,
+        category_repository: DjangoORMCategoryRepository,
+    ):
+        """
+        Test that the API returns 204 when the given ID exists and the name is updated.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given ID exists,
+        it should return a 204 status code and update only the name of the category.
+
+        The expected result is a 204 status code.
+        """
+        category_repository.save(category_movie)
+        url = f"/api/categories/{category_movie.id}/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "name": "Movies 2",
+            },
+        )
+
+        assert response.status_code, HTTP_204_NO_CONTENT
+
+        partial_updated_category = category_repository.get_by_id(category_movie.id)
+        assert partial_updated_category.name == "Movies 2"
+        assert partial_updated_category.description == category_movie.description
+        assert partial_updated_category.is_active == category_movie.is_active
+
+    def test_when_category_exists_update_only_description_and_return_204(
+        self,
+        category_movie: Category,
+        category_repository: DjangoORMCategoryRepository,
+    ):
+        """
+        Test that the API returns 204 when the given ID exists and the description is updated.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given ID exists,
+        it should return a 204 status code and update only the description of the category.
+
+        The expected result is a 204 status code.
+        """
+        category_repository.save(category_movie)
+        url = f"/api/categories/{category_movie.id}/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "description": "Movies category updated",
+            },
+        )
+
+        assert response.status_code, HTTP_204_NO_CONTENT
+
+        partial_updated_category = category_repository.get_by_id(category_movie.id)
+        assert partial_updated_category.name == category_movie.name
+        assert partial_updated_category.description == "Movies category updated"
+        assert partial_updated_category.is_active == category_movie.is_active
+
+    def test_when_category_exists_update_only_is_active_and_return_204(
+        self,
+        category_movie: Category,
+        category_repository: DjangoORMCategoryRepository,
+    ):
+        """
+        Test that the API returns 204 when the given ID exists and the is_active is updated.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given ID exists,
+        it should return a 204 status code and update only the is_active of the category.
+
+        The expected result is a 204 status code.
+        """
+        category_repository.save(category_movie)
+        url = f"/api/categories/{category_movie.id}/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "is_active": False,
+            },
+        )
+
+        assert response.status_code, HTTP_204_NO_CONTENT
+
+        partial_updated_category = category_repository.get_by_id(category_movie.id)
+        assert partial_updated_category.name == category_movie.name
+        assert partial_updated_category.description == category_movie.description
+        assert partial_updated_category.is_active == False
+
+    def test_when_category_exists_update_all_fields_and_return_204(
+        self,
+        category_movie: Category,
+        category_repository: DjangoORMCategoryRepository,
+    ):
+        """
+        Test that the API returns 204 when the given ID exists and all fields are updated.
+
+        When the API is called with PATCH /api/categories/<id>/ and the given ID exists,
+        it should return a 204 status code and update all fields of the category.
+
+        The expected result is a 204 status code.
+        """
+        category_repository.save(category_movie)
+        url = f"/api/categories/{category_movie.id}/"
+        response = APIClient().patch(
+            path=url,
+            data={
+                "name": "Movies 2",
+                "description": "Movies category updated",
+                "is_active": False,
+            },
+        )
+
+        assert response.status_code, HTTP_204_NO_CONTENT
+
+        partial_updated_category = category_repository.get_by_id(category_movie.id)
+        assert partial_updated_category.name == "Movies 2"
+        assert partial_updated_category.description == "Movies category updated"
+        assert partial_updated_category.is_active == False

--- a/src/django_project/category_app/views.py
+++ b/src/django_project/category_app/views.py
@@ -86,7 +86,7 @@ class CategoryViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         try:
-            req = GetCategoryRequest(id=serializer.validated_data["id"])
+            req = GetCategoryRequest(id=serializer.validated_data["id"])  # type: ignore
             use_case = GetCategory(DjangoORMCategoryRepository())
             res = use_case.execute(req)
         except CategoryNotFound:
@@ -116,9 +116,9 @@ class CategoryViewSet(viewsets.ViewSet):
         serializer = CreateCategoryRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        input = CreateCategoryRequest(**serializer.validated_data)
+        req = CreateCategoryRequest(**serializer.validated_data)  # type: ignore
         use_case = CreateCategory(DjangoORMCategoryRepository())
-        output = use_case.execute(input)
+        output = use_case.execute(req)
 
         return Response(
             data=CreateCategoryResponseSerializer(instance=output).data,
@@ -145,11 +145,11 @@ class CategoryViewSet(viewsets.ViewSet):
         )
         serializer.is_valid(raise_exception=True)
 
-        input = UpdateCategoryRequest(**serializer.validated_data)
+        req = UpdateCategoryRequest(**serializer.validated_data)  # type: ignore
         use_case = UpdateCategory(DjangoORMCategoryRepository())
 
         try:
-            use_case.execute(input)
+            use_case.execute(req)
         except CategoryNotFound:
             return Response(
                 data={"detail": "Category not found"},
@@ -175,7 +175,7 @@ class CategoryViewSet(viewsets.ViewSet):
         serializer = DeleteCategoryRequestSerializer(data={"id": pk})
         serializer.is_valid(raise_exception=True)
 
-        req = DeleteCategoryRequest(id=pk)
+        req = DeleteCategoryRequest(id=pk)  # type: ignore
         use_case = DeleteCategory(DjangoORMCategoryRepository())
         try:
             use_case.execute(req)
@@ -210,11 +210,11 @@ class CategoryViewSet(viewsets.ViewSet):
         )
         serializer.is_valid(raise_exception=True)
 
-        input = UpdateCategoryRequest(**serializer.validated_data)
+        req = UpdateCategoryRequest(**serializer.validated_data)  # type: ignore
         use_case = UpdateCategory(DjangoORMCategoryRepository())
 
         try:
-            use_case.execute(input)
+            use_case.execute(req)
         except CategoryNotFound:
             return Response(
                 data={"detail": "Category not found"},

--- a/src/tests_e2e/test_user_can_create_and_edit_category.py
+++ b/src/tests_e2e/test_user_can_create_and_edit_category.py
@@ -4,6 +4,10 @@ from rest_framework.test import APIClient
 
 @pytest.mark.django_db
 class TestCreateAndEditCategory:
+    """
+    Test class for testing user can create and edit a category
+    """
+
     def test_user_can_create_and_edit_category(self) -> None:
         """
         Verify that a user can create and edit a category, and that the edited
@@ -17,7 +21,7 @@ class TestCreateAndEditCategory:
 
         # Verify that list categories is empty
         list_response = api_client.get("/api/categories/")
-        assert list_response.status_code == 200
+        assert list_response.status_code == 200  # type: ignore
 
         # Create category
         create_response = api_client.post(
@@ -25,14 +29,14 @@ class TestCreateAndEditCategory:
             data={"name": "Test Category", "description": "Test Category Description"},
             format="json",
         )
-        assert create_response.status_code == 201
-        category_response_id = create_response.data["id"]
+        assert create_response.status_code == 201  # type: ignore
+        category_response_id = create_response.data["id"]  # type: ignore
 
         # Verify that category was created
         list_response = api_client.get("/api/categories/")
-        assert list_response.status_code == 200
-        assert len(list_response.data["data"]) == 1
-        assert list_response.data == {
+        assert list_response.status_code == 200  # type: ignore
+        assert len(list_response.data["data"]) == 1  # type: ignore
+        assert list_response.data == {  # type: ignore
             "data": [
                 {
                     "id": category_response_id,
@@ -45,8 +49,8 @@ class TestCreateAndEditCategory:
 
         # Verify that category is active
         get_response = api_client.get(f"/api/categories/{category_response_id}/")
-        assert get_response.status_code == 200
-        assert get_response.data == {
+        assert get_response.status_code == 200  # type: ignore
+        assert get_response.data == {  # type: ignore
             "data": {
                 "id": category_response_id,
                 "name": "Test Category",
@@ -65,13 +69,13 @@ class TestCreateAndEditCategory:
             },
             format="json",
         )
-        assert update_response.status_code == 204
+        assert update_response.status_code == 204  # type: ignore
 
         # Verify that category was updated
         list_response = api_client.get("/api/categories/")
-        assert list_response.status_code == 200
-        assert len(list_response.data["data"]) == 1
-        assert list_response.data == {
+        assert list_response.status_code == 200  # type: ignore
+        assert len(list_response.data["data"]) == 1  # type: ignore
+        assert list_response.data == {  # type: ignore
             "data": [
                 {
                     "id": category_response_id,
@@ -84,9 +88,9 @@ class TestCreateAndEditCategory:
 
         # Delete category
         delete_response = api_client.delete(f"/api/categories/{category_response_id}/")
-        assert delete_response.status_code == 204
+        assert delete_response.status_code == 204  # type: ignore
 
         # Verify that category was deleted
         list_response = api_client.get("/api/categories/")
-        assert list_response.status_code == 200
-        assert len(list_response.data["data"]) == 0
+        assert list_response.status_code == 200  # type: ignore
+        assert len(list_response.data["data"]) == 0  # type: ignore


### PR DESCRIPTION
Atualmente só permitimos o update com o put, onde todos os campos da nossa entidade são alterados com as informações no payload da requisição. Agora precisamos implementar o patch, onde permitimos que apenas alguns campos sejam alterados.

Instruções:
Adicionar o método partial_update em views.py

def partial_update(self, request, pk: UUID = None) -> Response
    ...

Em relação ao serializer, tem duas opções:
- criar um serializer apenas para para a requisição HTTP específica – com todos os campos como opcionais "required=False" (name, description, is_active). 
- Utilizar o UpdateCategoryRequestSerializer e passar o argumento partial=True:

        serializer = UpdateCategoryRequestSerializer(data={
            **request.data,
            "id": pk,
        }, partial=True)

Nossa entidade deve ser atualizada apenas com os valores passados. Ou seja, caso o payload contenha apenas "description", apenas esse campo na entidade deve ser atualizado.

Lembre-se que o pk  vai ser sempre passado, similar ao que fizemos com o update.

Escreva testes onde o payload de cada teste contém apenas um dos campos editáveis: name, description e is_active.

Lembre-se de verificar que os outros campos não foram alterados.

Não se esqueça de adicionar em seu projeto um arquivo chamado requirements.txt para listar todas as dependências do seu projeto Python. Esse arquivo é usado pelo pip para instalar as bibliotecas necessárias para o funcionamento correto da aplicação.