### PR TITLE
Challenge-update-genre-use-case

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 pythonpath = src
 DJANGO_SETTINGS_MODULE = django_project.settings
 python_files = tests.py test_*.py *_tests.py
+addopts = --import-mode=importlib

--- a/src/core/genre/application/use_cases/create_genre.py
+++ b/src/core/genre/application/use_cases/create_genre.py
@@ -9,6 +9,10 @@ from src.core.genre.domain.genre import Genre
 
 
 class CreateGenre:
+    """
+    Create a new genre with the given name and categories.
+    """
+
     def __init__(
         self,
         genre_repository,

--- a/src/core/genre/application/use_cases/update_genre.py
+++ b/src/core/genre/application/use_cases/update_genre.py
@@ -1,0 +1,100 @@
+import uuid
+from dataclasses import dataclass, field
+
+from src.core.category.domain.category_repository import CategoryRepository
+from src.core.genre.application.exceptions import (
+    GenreNotFound,
+    InvalidGenre,
+    RelatedCategoriesNotFound,
+)
+from src.core.genre.domain.genre_repository import GenreRepository
+
+
+class UpdateGenre:
+    """
+    Update a genre in the repository.
+    """
+
+    def __init__(
+        self,
+        genre_repository: GenreRepository,
+        category_repository: CategoryRepository,
+    ):
+        """
+        Initialize the UpdateGenre use case.
+
+        Args:
+            genre_repository (GenreRepository): The genre repository.
+            category_repository (CategoryRepository): The category repository.
+        """
+        self.genre_repository = genre_repository
+        self.category_repository = category_repository
+
+    @dataclass
+    class Input:
+        """
+        Input for the UpdateGenre use case.
+        """
+
+        id: uuid.UUID
+        name: str
+        is_active: bool
+        category_ids: set[uuid.UUID] = field(default_factory=set)
+
+    @dataclass
+    class Output:
+        """
+        Output for the UpdateGenre use case.
+        """
+
+        id: uuid.UUID
+        name: str
+        is_active: bool
+        categories: set[uuid.UUID]
+
+    def execute(self, input: Input) -> Output:
+        """
+        Execute the UpdateGenre use case.
+
+        Args:
+            input (Input): The input for the use case.
+
+        Returns:
+            Output: The output of the use case.
+        """
+        genre = self.genre_repository.get_by_id(genre_id=input.id)
+
+        if genre is None:
+            raise GenreNotFound(f"Genre with ID {input.id} not found")
+
+        current_name = genre.name
+
+        try:
+            if input.name is not None:
+                current_name = input.name
+
+            genre.change_name(current_name)
+
+            if input.is_active is True:
+                genre.activate()
+
+            if input.is_active is False:
+                genre.deactivate()
+
+        except ValueError as err:
+            raise InvalidGenre(err) from err
+
+        category_ids = {category.id for category in self.category_repository.list()}
+        if not input.category_ids.issubset(category_ids):
+            raise RelatedCategoriesNotFound(
+                f"Categories not found: {input.category_ids - category_ids}"
+            )
+
+        genre.categories = input.category_ids
+
+        return self.Output(
+            id=genre.id,
+            name=genre.name,
+            is_active=genre.is_active,
+            categories=genre.categories,
+        )

--- a/src/core/genre/tests/application/use_cases/integration/test_update_genre.py
+++ b/src/core/genre/tests/application/use_cases/integration/test_update_genre.py
@@ -1,0 +1,171 @@
+import uuid
+
+import pytest
+
+from src.core.category.domain.category import Category
+from src.core.category.infra.in_memory_category_repository import (
+    InMemoryCategoryRepository,
+)
+from src.core.genre.application.exceptions import (
+    GenreNotFound,
+    InvalidGenre,
+    RelatedCategoriesNotFound,
+)
+from src.core.genre.application.use_cases.update_genre import UpdateGenre
+from src.core.genre.domain.genre import Genre
+from src.core.genre.infra.in_memory_genre_repository import InMemoryGenreRepository
+
+
+class TestDeleteGenre:
+    """
+    Test class for the `update_genre` use case.
+    """
+
+    def test_update_not_existing_genre_raises_exception(self):
+        """
+        When calling update_genre() with a non-existent genre ID, it raises a
+        GenreNotFound exception.
+
+        This test verifies that the `update_genre` use case raises a
+        GenreNotFound exception when the genre is not found in the repository.
+        """
+
+        use_case = UpdateGenre(
+            genre_repository=InMemoryGenreRepository(),
+            category_repository=InMemoryCategoryRepository(),
+        )
+        with pytest.raises(GenreNotFound, match="Genre with .* not found"):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=uuid.uuid4(),
+                    name="Horror",
+                    is_active=True,
+                    category_ids=set(),
+                )
+            )
+
+    def test_update_genre_with_invalid_input_raises_exception(self):
+        """
+        When calling update_genre() with an invalid Genre (e.g. with an empty name),
+        it raises an InvalidGenre exception.
+
+        This test verifies that the `update_genre` use case raises an
+        `InvalidGenre` exception when the given Genre is invalid.
+        """
+
+        genre_id = uuid.uuid4()
+        use_case = UpdateGenre(
+            genre_repository=InMemoryGenreRepository(
+                genres=[
+                    Genre(
+                        id=genre_id,
+                        name="Horror",
+                    )
+                ]
+            ),
+            category_repository=InMemoryCategoryRepository(),
+        )
+        with pytest.raises(InvalidGenre, match="Name cannot be empty"):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=genre_id,
+                    name="",
+                    is_active=False,
+                    category_ids=set(),
+                )
+            )
+
+    def test_update_genre_with_invalid_related_categories_raises_exception(self):
+        """
+        When calling update_genre() with a set of category IDs that do not
+        exist in the repository, it raises a RelatedCategoriesNotFound exception.
+
+        This test verifies that the `update_genre` use case raises a
+        `RelatedCategoriesNotFound` exception when the given category IDs do not exist
+        in the repository.
+        """
+
+        genre_id = uuid.uuid4()
+        use_case = UpdateGenre(
+            genre_repository=InMemoryGenreRepository(
+                genres=[
+                    Genre(
+                        id=genre_id,
+                        name="Horror",
+                    )
+                ]
+            ),
+            category_repository=InMemoryCategoryRepository(categories=[]),
+        )
+
+        with pytest.raises(
+            RelatedCategoriesNotFound,
+            match="Categories not found: .*",
+        ):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=genre_id,
+                    name="Horror",
+                    is_active=True,
+                    category_ids={uuid.uuid4()},
+                )
+            )
+
+    def test_update_genre_with_valid_input(self):
+        """
+        When calling update_genre() with a valid Genre, it updates the genre in
+        the repository and returns the updated Genre.
+
+        This test verifies that the `update_genre` use case updates the genre in
+        the repository and returns the updated Genre.
+        """
+        movie_category = Category(
+            name="Movie",
+            description="Movies category",
+        )
+        documentary_category = Category(
+            name="Documentary",
+            description="Documentary category",
+        )
+        cartoon_category = Category(
+            name="Cartoon",
+            description="Cartoon category",
+        )
+
+        genre_id = uuid.uuid4()
+
+        use_case = UpdateGenre(
+            genre_repository=InMemoryGenreRepository(
+                genres=[
+                    Genre(
+                        id=genre_id,
+                        name="Horror",
+                        is_active=True,
+                        categories={
+                            cartoon_category.id,
+                            documentary_category.id,
+                        },
+                    )
+                ]
+            ),
+            category_repository=InMemoryCategoryRepository(
+                [
+                    cartoon_category,
+                    documentary_category,
+                    movie_category,
+                ]
+            ),
+        )
+        result = use_case.execute(
+            input=UpdateGenre.Input(
+                id=genre_id,
+                name="Horror Updated",
+                is_active=False,
+                category_ids={movie_category.id},
+            )
+        )
+
+        assert result.id == genre_id
+        assert result.name == "Horror Updated"
+        assert result.is_active is False
+        assert result.categories == {movie_category.id}

--- a/src/core/genre/tests/application/use_cases/unit/test_update_genre.py
+++ b/src/core/genre/tests/application/use_cases/unit/test_update_genre.py
@@ -1,0 +1,289 @@
+import uuid
+from unittest.mock import create_autospec
+
+import pytest
+
+from src.core.category.domain.category import Category
+from src.core.category.domain.category_repository import CategoryRepository
+from src.core.genre.application.exceptions import (
+    GenreNotFound,
+    InvalidGenre,
+    RelatedCategoriesNotFound,
+)
+from src.core.genre.application.use_cases.update_genre import UpdateGenre
+from src.core.genre.domain.genre import Genre
+from src.core.genre.domain.genre_repository import GenreRepository
+
+
+@pytest.fixture
+def movie_category() -> Category:
+    """
+    Fixture for a Category instance representing movies.
+
+    Returns:
+        Category: A Category object with name "Movie" and description "Movies category".
+    """
+
+    return Category(
+        name="Movie",
+        description="Movies category",
+    )
+
+
+@pytest.fixture
+def documentary_category() -> Category:
+    """
+    Fixture for a Category instance representing documentaries.
+
+    Returns:
+        Category: A Category object with name "Documentary" and description "Documentary category".
+    """
+
+    return Category(
+        name="Documentary",
+        description="Documentary category",
+    )
+
+
+@pytest.fixture
+def genre_id() -> uuid.UUID:
+    """
+    Fixture for a UUID representing a genre ID.
+
+    Returns:
+        uuid.UUID: A UUID object.
+    """
+
+    return uuid.UUID("6030fb56-cd39-483d-bf09-c0d930c45739")
+
+
+@pytest.fixture
+def horror_genre(
+    genre_id: uuid.UUID,
+    movie_category: Category,
+) -> Genre:
+    """
+    Fixture for a Genre instance representing Horror movies.
+
+    Returns:
+        Genre: A Genre object with name "Horror" and the movie category.
+    """
+
+    return Genre(
+        id=genre_id,
+        name="Horror",
+        categories={
+            movie_category.id,
+        },
+    )
+
+
+@pytest.fixture
+def horror_genre_updated(
+    genre_id: uuid.UUID,
+    movie_category: Category,
+    documentary_category: Category,
+) -> Genre:
+    """
+    Fixture for a Genre instance representing Horror movies with the movie and
+    documentary categories.
+
+    Returns:
+        Genre: A Genre object with name "Horror" and the movie and documentary
+        categories.
+    """
+    return Genre(
+        id=genre_id,
+        name="Horror Updated",
+        is_active=False,
+        categories={
+            movie_category.id,
+            documentary_category.id,
+        },
+    )
+
+
+@pytest.fixture
+def mock_genre_repository(horror_genre_updated: Genre) -> GenreRepository:
+    """
+    Fixture for a mock GenreRepository instance.
+
+    Returns:
+        GenreRepository: A mock GenreRepository object.
+    """
+
+    repository = create_autospec(GenreRepository)
+    repository.update.return_value = horror_genre_updated
+    return repository
+
+
+@pytest.fixture
+def mock_category_repository_with_categories(
+    movie_category: Category,
+    documentary_category: Category,
+) -> CategoryRepository:
+    """
+    Fixture for a mock CategoryRepository instance that contains the movie and
+    documentary categories.
+
+    This fixture is used to provide a mock CategoryRepository that contains the
+    movie and documentary categories, which can then be used in tests to verify
+    that the get_categories_list use case returns the correct categories.
+
+    Returns:
+        CategoryRepository: A mock CategoryRepository that contains the movie
+        and documentary categories.
+    """
+
+    repository = create_autospec(CategoryRepository)
+    repository.list.return_value = [movie_category, documentary_category]
+    return repository
+
+
+class TestDeleteGenre:
+    """
+    Test suite for the UpdateGenre use case.
+    """
+
+    def test_update_not_existing_genre_raises_exception(
+        self,
+        mock_genre_repository: GenreRepository,
+        mock_category_repository_with_categories: CategoryRepository,
+    ):
+        """
+        When calling update_genre() with a non-existent genre ID, it raises a
+        GenreNotFound exception.
+
+        This test verifies that the `update_genre` use case raises a
+        GenreNotFound exception when the genre is not found in the repository.
+        """
+
+        mock_genre_repository.get_by_id.return_value = None  # type: ignore
+        use_case = UpdateGenre(
+            genre_repository=mock_genre_repository,
+            category_repository=mock_category_repository_with_categories,
+        )
+        with pytest.raises(GenreNotFound, match="Genre with .* not found"):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=uuid.uuid4(),
+                    name="Horror",
+                    is_active=True,
+                    category_ids=set(),
+                )
+            )
+
+        mock_genre_repository.update.assert_not_called()  # type: ignore
+
+    def test_update_genre_with_invalid_input_raises_exception(
+        self,
+        mock_genre_repository: GenreRepository,
+        mock_category_repository_with_categories: CategoryRepository,
+        horror_genre: Genre,
+    ):
+        """
+        When calling update_genre() with an invalid Genre (e.g. with an empty name),
+        it raises an InvalidGenre exception.
+
+        This test verifies that the `update_genre` use case raises an
+        `InvalidGenre` exception when the given Genre is invalid.
+
+        Args:
+            mock_genre_repository (GenreRepository): A mock GenreRepository object.
+            mock_category_repository_with_categories (CategoryRepository): A mock
+            CategoryRepository containing the movie and documentary categories.
+            horror_genre (Genre): A Genre object with name "Horror".
+        """
+        mock_genre_repository.get_by_id.return_value = horror_genre  # type: ignore
+        use_case = UpdateGenre(
+            genre_repository=mock_genre_repository,
+            category_repository=mock_category_repository_with_categories,
+        )
+        with pytest.raises(InvalidGenre, match="Name cannot be empty"):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=uuid.uuid4(),
+                    name="",
+                    is_active=True,
+                    category_ids=set(),
+                )
+            )
+
+        mock_genre_repository.update.assert_not_called()  # type: ignore
+
+    def test_update_genre_with_invalid_related_categories_raises_exception(
+        self,
+        mock_genre_repository: GenreRepository,
+        mock_category_repository_with_categories: CategoryRepository,
+        horror_genre: Genre,
+    ):
+        """
+        When calling update_genre() with a set of category IDs that do not
+        exist in the repository, it raises a RelatedCategoriesNotFound exception.
+
+        This test verifies that the `update_genre` use case raises a
+        `RelatedCategoriesNotFound` exception when the given category IDs do not exist
+        in the repository.
+        """
+        use_case = UpdateGenre(
+            genre_repository=mock_genre_repository,
+            category_repository=mock_category_repository_with_categories,
+        )
+        mock_genre_repository.get_by_id.return_value = horror_genre  # type: ignore
+        with pytest.raises(
+            RelatedCategoriesNotFound,
+            match="Categories not found: .*",
+        ):
+            use_case.execute(
+                input=UpdateGenre.Input(
+                    id=horror_genre.id,
+                    name=horror_genre.name,
+                    is_active=True,
+                    category_ids={uuid.uuid4()},
+                )
+            )
+
+        mock_genre_repository.update.assert_not_called()  # type: ignore
+
+    def test_update_genre_with_valid_input(
+        self,
+        mock_genre_repository: GenreRepository,
+        mock_category_repository_with_categories: CategoryRepository,
+        genre_id: uuid.UUID,
+        horror_genre: Genre,
+        movie_category: Category,
+        documentary_category: Category,
+    ):
+        """
+        When calling update_genre() with a valid Genre, it updates the genre in
+        the repository and returns the updated Genre.
+
+        This test verifies that the `update_genre` use case updates the genre in
+        the repository and returns the updated Genre.
+        """
+        mock_genre_repository.get_by_id.return_value = horror_genre  # type: ignore
+        use_case = UpdateGenre(
+            genre_repository=mock_genre_repository,
+            category_repository=mock_category_repository_with_categories,
+        )
+        result = use_case.execute(
+            input=UpdateGenre.Input(
+                id=genre_id,
+                name="Horror Updated",
+                is_active=False,
+                category_ids={
+                    movie_category.id,
+                    documentary_category.id,
+                },
+            )
+        )
+
+        assert result == UpdateGenre.Output(
+            id=genre_id,
+            name="Horror Updated",
+            is_active=False,
+            categories={
+                movie_category.id,
+                documentary_category.id,
+            },
+        )


### PR DESCRIPTION
Desafio: implementar o caso de uso de atualizar gênero

Os atributos passados devem substituir totalmente os atributos da entidade (comportamento similar ao PUT e não ao PATCH).

Casos de teste (pode escolher fazer mais unitários e apenas o "happy path" de integração):

- Atualizar um Genre que não existe deve retornar um GenreNotFound Exception

- Atualizar um Genre passando atributos inválidos deve retonar uma InvalidGenre Exception

- Atualizar um Genre com categorias que não existem deve retornar um RelatedCategoriesNotFound Exception

- Atualizar um Genre com categorias que existem deve atualizar o Genre corretamente

  - Lembrando que vamos atualizar o Genre totalmente. Se ele tinha 3 categorias e passamos 2, ele deve ficar com 2 categorias.

  - Incluir atributos como "name" e "is_active" no teste

Link:  https://github.com/gcrsaldanha/codeflix-catalog-admin/blob/main/roteiro/modulo-7-genre-domain.md#desafio---caso-de-uso-atualizar-g%C3%AAnero
 
Não se esqueça de adicionar em seu projeto um arquivo chamado requirements.txt para listar todas as dependências do seu projeto Python. Esse arquivo é usado pelo pip para instalar as bibliotecas necessárias para o funcionamento correto da aplicação.